### PR TITLE
Coveralls fix avoiding Demo files

### DIFF
--- a/pubnative-ios-library.xcworkspace/contents.xcworkspacedata
+++ b/pubnative-ios-library.xcworkspace/contents.xcworkspacedata
@@ -39,6 +39,9 @@
          location = "group:remove_keys.sh">
       </FileRef>
       <FileRef
+         location = "group:coveralls.sh">
+      </FileRef>
+      <FileRef
          location = "group:coveralls.rb">
       </FileRef>
    </Group>

--- a/travis/coveralls.rb
+++ b/travis/coveralls.rb
@@ -98,7 +98,7 @@ Find.find(derivedDataDir) do |gcda_file|
             shouldProcess = false
             exclusionMsg =""
 
-            if (excludedFolders.include?(path_comps[0]))
+            if(excludedFolders.any?{|excludedFolder| path_comps[0].start_with?(excludedFolder)})
               exclusionMsg = "excluded via option"
             else
               if (excludeHeaders == true && extension == 'h')

--- a/travis/coveralls.sh
+++ b/travis/coveralls.sh
@@ -10,4 +10,4 @@ xctool -workspace pubnative-ios-library.xcworkspace \
 	   GCC_GENERATE_TEST_COVERAGE_FILES=YES \
 	   clean test
 
-./travis/coveralls.rb --extension m --exclude-folder PubNativeDemo/PubNativeDemoTests PubNativeDemo/PubNativeDemo
+./travis/coveralls.rb --extension m --exclude-folder PubNativeDemo


### PR DESCRIPTION
This patch makes the coveralls script file better avoiding folders by directory structure instead of full directory before the file.

The result is full avoid of Demo app folder files