### PR TITLE
Improved CI performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ before_script:
 - env
 - ./travis/add_keys.sh
 script:
-- xctool -workspace pubnative-ios-library.xcworkspace -scheme PubnativeDemo -sdk iphonesimulator clean build test
+- xctool -workspace pubnative-ios-library.xcworkspace -scheme PubnativeDemo -sdk iphonesimulator -configuration Debug ONLY_ACTIVE_ARCH=NO GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES clean build test
 after_success:
-- ./travis/testflight.sh
 - ./travis/coveralls.sh
+- ./travis/testflight.sh
 after_failure: 
 after_script:
 - ./travis/remove_keys.sh

--- a/travis/coveralls.sh
+++ b/travis/coveralls.sh
@@ -1,13 +1,4 @@
 echo "*********************"
 echo "*     COVERALLS     *"
 echo "*********************"
-xctool -workspace pubnative-ios-library.xcworkspace \
-	   -scheme PubnativeDemo \
-	   -sdk iphonesimulator \
-	   -configuration Debug \
-	   ONLY_ACTIVE_ARCH=NO \
-	   GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES \
-	   GCC_GENERATE_TEST_COVERAGE_FILES=YES \
-	   clean test
-
 ./travis/coveralls.rb --extension m --exclude-folder PubNativeDemo --exclude-folder 'PubNative/External'


### PR DESCRIPTION
This patch makes travis quiclkier compiling, since it will make it in 5 steps instead of 7

* CLEAN
* DEBUG (build)
* DEBUG (test)
* CLEAN
* RELEASE (build)

while before this  it was:

* CLEAN
* DEBUG (build)
* DEBUG (test)
* CLEAN
* DEBUG (test)
* CLEAN
* RELEASE (build)