### PR TITLE
Builds upload to Hockey

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: objective-c
 xcode_workspace: pubnative-ios-library.xcworkspace
 xcode_scheme: PubnativeDemo
-before_install: 
+before_install:
 - sudo easy_install cpp-coveralls
 - chmod a+x travis/add_keys.sh
 - chmod a+x travis/testflight.sh
+- chmod a+x travis/hockey.sh
 - chmod a+x travis/coveralls.sh
 - chmod a+x travis/coveralls.rb
 - chmod a+x travis/remove_keys.sh
@@ -13,10 +14,12 @@ before_script:
 - env
 - ./travis/add_keys.sh
 script:
-- xctool -workspace pubnative-ios-library.xcworkspace -scheme PubnativeDemo -sdk iphonesimulator -configuration Debug ONLY_ACTIVE_ARCH=NO GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES clean build test
+- xctool -workspace pubnative-ios-library.xcworkspace -scheme PubnativeDemo -sdk iphonesimulator
+  -configuration Debug ONLY_ACTIVE_ARCH=NO GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES
+  clean build test
 after_success:
 - ./travis/coveralls.sh
-- ./travis/testflight.sh
+- ./travis/hockey.sh
 after_failure: 
 after_script:
 - ./travis/remove_keys.sh
@@ -25,3 +28,5 @@ env:
   - secure: VMvLNeF8N4YbW/BgQzzjpWs7UxgZ9HdS3SKL+6KaCXnfxYu0bDBdPVA5bqXfDaHFcTdrC4Tp40UPC0+aE+d4rLHbh9G3WdQO+hdg+fhNIkNnibHXBaXI5E653TyPH+zoUr2dU36VPnGji3RiprEF7GK3k1TzBwpb46M2GzPcCrE=
   - secure: X84c9HjA4X3WcvU01kDXzdIsiRDGlZWnG/pg5onF/uwai/ArLYPGvhbGo3z5T9zE97C8PFvIXTL5Oc4XibDRtHRx28YdyNNzI91EVYYwRlpXTMWyB2HaDAXnpf2W6kKbpJ+UJ8Pwme75x2w16ClY0nvv8S/qXar5SFODH97ntmg=
   - secure: aWYA0kWuy+Fn8iaoceCTYvz8u6M8DHVqZtMAss39Sx1p+A0i7jt/mrnNlysQNSzrUdtgPhQosG/4lENpSoj/CzroaF+1EJzwhNjIaa7dyQ6juWrd0VfigJKifaCsp9uxIq3ggvkyB+oSZW0IlcPp/BM6+143x/3+Ym5huc7bgo0=
+  - secure: jAeff80L5BvfjnCScijjCpnB/Cho6IM6FW7b/TuANNoZXvL4DrbDWAAbeobl9kdBqlh3MmFHaVUE2fWdhToxRGOr/6xqAUgWtMGclwpdNxYkGkM3Txk/8ugpgMTMzJjOvzhEOJZcYsrHD6ZhCiDuif6Yn0Gv1U4SxsJp3W2Bfe0=
+  - secure: JbMI1ojET9TCtZwOVLDUM37TH8lVLZlpVT+YGHec0shxG0XfYtHZuK5sI9PXrEqM28GVv8csKHyTOif1wb/E9GTa5kRXZ3qGP7xeCi8VOAOS5dlEy4OV5LaS8E6LmTmymmgh0UB9rQ0HYy1imve5rYqfsmC68HFX0gbQ6U/s2tE=

--- a/pubnative-ios-library.xcworkspace/contents.xcworkspacedata
+++ b/pubnative-ios-library.xcworkspace/contents.xcworkspacedata
@@ -36,6 +36,9 @@
          location = "group:testflight.sh">
       </FileRef>
       <FileRef
+         location = "group:hockey.sh">
+      </FileRef>
+      <FileRef
          location = "group:remove_keys.sh">
       </FileRef>
       <FileRef

--- a/travis/hockey.sh
+++ b/travis/hockey.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+  echo "This is a pull request. No deployment will be done."
+  exit 0
+fi
+if [[ "$TRAVIS_BRANCH" != "development" ]]; then
+  echo "Testing other branch than development. No deployment will be done."
+  exit 0
+fi
+
+PROVISIONING_PROFILE="$HOME/Library/MobileDevice/Provisioning Profiles/distribution.mobileprovision"
+DEVELOPER_NAME="iPhone Distribution: HitFox App Discovery GMBH"
+APP_NAME="PubnativeDemo"
+
+echo "****************************"
+echo "*     BUILDING RELEASE     *"
+echo "****************************"
+xctool -workspace pubnative-ios-library.xcworkspace \
+       -scheme PubnativeDemo \
+       -sdk iphoneos \
+       -configuration Release \
+       OBJROOT=$TRAVIS_BUILD_DIR \
+       SYMROOT=$TRAVIS_BUILD_DIR \
+       clean build
+
+echo "****************************"
+echo "*       BUILDING IPA       *"
+echo "****************************"
+xcrun -log -sdk iphoneos PackageApplication "$TRAVIS_BUILD_DIR/Release-iphoneos/$APP_NAME.app" -o "$TRAVIS_BUILD_DIR/$APP_NAME.ipa" -sign "$DEVELOPER_NAME" -embed "$PROVISIONING_PROFILE"
+
+echo "****************************"
+echo "*    ZIPPING dSYM FILE     *"
+echo "****************************"
+zip -r -9 "$TRAVIS_BUILD_DIR/$APP_NAME.app.dSYM.zip" "$TRAVIS_BUILD_DIR/Release-iphoneos/$APP_NAME.app.dSYM"
+
+echo "****************************"
+echo "*   UPLOAD TO HOCKEY   *"
+echo "****************************"
+RELEASE_NOTES="Travis CI Build: $TRAVIS_BUILD_NUMBER"
+curl https://rink.hockeyapp.net/api/2/apps/$HOCKEY_APP_ID/app_versions \
+-H "X-HockeyAppToken: $HOCKEY_API_TOKEN" \
+-F ipa="@$TRAVIS_BUILD_DIR/$APP_NAME.ipa" \
+-F dsym="@$TRAVIS_BUILD_DIR/$APP_NAME.app.dSYM.zip" \
+-F notes="$RELEASE_NOTES" \
+-F notes_type="0" \
+-F notify="0" \
+-F status="2"
+
+


### PR DESCRIPTION
This patch changes Hockey as the default build manager instead of testflight