### PR TITLE
Video cacher fix

### DIFF
--- a/PubNative/Components/Common/Video/PNVideoPlayerView.m
+++ b/PubNative/Components/Common/Video/PNVideoPlayerView.m
@@ -394,7 +394,7 @@
 
 - (void)videoCacherDidFail:(NSError *)error
 {
-    [self invokeVideoError:0 withDetails:@"Ad video URL null"];
+    [self invokeVideoError:0 withDetails:[error description]];
 }
 
 #pragma mark PNVideoPlayerDelegate

--- a/PubNative/Components/Feed/Video/PNVideoTableViewCell.m
+++ b/PubNative/Components/Feed/Video/PNVideoTableViewCell.m
@@ -261,9 +261,13 @@ FOUNDATION_IMPORT NSString * const kPNTableViewManagerClearAllNotification;
     [self.contentView addSubview:self.playerContainer.view];
 }
 
+- (void)videoError:(NSInteger)errorCode details:(NSString*)description
+{
+    NSLog(@"Video error: %@", description);
+}
+
 - (void)videoPreparing {}
 - (void)videoStartedWithDuration:(NSTimeInterval)duration {}
-- (void)videoError:(NSInteger)errorCode details:(NSString*)description {}
 - (void)videoProgress:(NSTimeInterval)currentTime duration:(NSTimeInterval)duration {}
 - (void)videoTrackingEvent:(NSString*)event {}
 

--- a/PubNative/Components/Native/Video/PNVideoInterstitialViewController.m
+++ b/PubNative/Components/Native/Video/PNVideoInterstitialViewController.m
@@ -231,7 +231,11 @@ NSString * const kPNVideoInterstitialViewControllerFrameKey = @"view.frame";
 - (void)videoDismissedFullscreen{}
 - (void)videoPreparing {}
 - (void)videoStartedWithDuration:(NSTimeInterval)duration {}
-- (void)videoError:(NSInteger)errorCode details:(NSString*)description {}
+- (void)videoError:(NSInteger)errorCode details:(NSString*)description
+{
+    NSLog(@"Video error: %@", description);
+}
+
 - (void)videoProgress:(NSTimeInterval)currentTime duration:(NSTimeInterval)duration {}
 - (void)videoTrackingEvent:(NSString*)event {}
 

--- a/PubNative/Components/Native/VideoBanner/PNVideoBannerViewController.m
+++ b/PubNative/Components/Native/VideoBanner/PNVideoBannerViewController.m
@@ -292,16 +292,6 @@
     self.playButton.hidden = NO;
 }
 
-- (void)videoPreparing
-{
-    
-}
-
-- (void)videoStartedWithDuration:(NSTimeInterval)duration
-{
-    
-}
-
 - (void)videoCompleted
 {
     UIViewController *presentingController = [UIApplication sharedApplication].keyWindow.rootViewController;
@@ -321,24 +311,14 @@
 
 - (void)videoError:(NSInteger)errorCode details:(NSString*)description
 {
+    NSLog(@"Video error: %@", description);
 }
 
-- (void)videoProgress:(NSTimeInterval)currentTime duration:(NSTimeInterval)duration
-{
-    
-}
-
-- (void)videoTrackingEvent:(NSString*)event
-{
-    
-}
-
-- (void)videoDismissedFullscreen
-{
-    
-}
-
-
+- (void)videoPreparing{}
+- (void)videoStartedWithDuration:(NSTimeInterval)duration{}
+- (void)videoProgress:(NSTimeInterval)currentTime duration:(NSTimeInterval)duration{}
+- (void)videoTrackingEvent:(NSString*)event{}
+- (void)videoDismissedFullscreen{}
 
 #pragma mark PNAdViewControllerDelegate
 


### PR DESCRIPTION
This patch fixes a problem with the PNVideoCacher that cached a 403 forbidden web page as a video.

For the solution I ensured that the downloaded data status is correct and the content type is a video type. Otherwise, an error is returned by the video.