### PR TITLE
Compatibility with non-arc projects forced inclusion

### DIFF
--- a/PubNative/Components/Common/Video/PNVideoPlayer.m
+++ b/PubNative/Components/Common/Video/PNVideoPlayer.m
@@ -76,7 +76,7 @@
     AVPlayer *avPlayer = [AVPlayer playerWithPlayerItem:playerItem];
     self.avPlayer = avPlayer;
     
-    __weak typeof(self) weakSelf = self;
+    __weak PNVideoPlayer *weakSelf = self;
     [self.avPlayer addPeriodicTimeObserverForInterval:CMTimeMakeWithSeconds(1.0 / 60.0, NSEC_PER_SEC)
                                                 queue:nil
                                            usingBlock:^(CMTime time) {

--- a/PubNative/Request/PNAdRequest.m
+++ b/PubNative/Request/PNAdRequest.m
@@ -105,7 +105,7 @@
     
     if(apiModel && apiURL)
     {
-        __weak typeof(self) weakSelf = self;
+        __weak PNAdRequest *weakSelf = self;
         [self.parameters fillWithDefaults];
         self.apiModel = [apiModel initWithURL:apiURL
                                        method:kPNAdConstantMethodGET

--- a/PubNativeDemo/PubNativeDemo/FeedViewController.m
+++ b/PubNativeDemo/PubNativeDemo/FeedViewController.m
@@ -100,7 +100,7 @@ NSString * const iconCellID     = @"iconCellID";
         self.navItem.title = @"In Feed";
     }
     
-    __weak typeof(self) weakSelf = self;
+    __weak FeedViewController *weakSelf = self;
     self.request = [PNAdRequest request:requestType
                          withParameters:parameters
                           andCompletion:^(NSArray *ads, NSError *error)

--- a/PubNativeDemo/PubNativeDemo/Info.plist
+++ b/PubNativeDemo/PubNativeDemo/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.2.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.2.0</string>
+	<string>1.2.1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/PubNativeDemo/PubNativeDemo/ViewController.m
+++ b/PubNativeDemo/PubNativeDemo/ViewController.m
@@ -66,7 +66,7 @@ NSString * const kPubnativeTestAppToken = @"e1a8e9fcf8aaeff31d1ddaee1f60810957f4
     [self.parameters fillWithDefaults];
     self.parameters.app_token = kPubnativeTestAppToken;
     
-    __weak typeof(self) weakSelf = self;
+    __weak ViewController *weakSelf = self;
     self.eventModel = [[EFApiModel alloc] initWithURL:[NSURL URLWithString:@"http://api.eventful.com/json/events/search"]
                                                method:@"GET"
                                                params:@{@"app_key"     : @"pd5PdshD44wckpD7",
@@ -79,7 +79,7 @@ NSString * const kPubnativeTestAppToken = @"e1a8e9fcf8aaeff31d1ddaee1f60810957f4
                                           cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
                                               timeout:30
                                    andCompletionBlock:^(NSError *error) {
-                                        __strong typeof(self) strongSelf = weakSelf;
+                                        __strong ViewController *strongSelf = weakSelf;
                                         [strongSelf processEventsWithError:error];
                                    }];
     NSDictionary *info = [[NSBundle mainBundle] infoDictionary];


### PR DESCRIPTION
This patch helps avoiding a compilation problem in non-arc projects that force include the library with -fobjc-arc compilation flag for files.

The typeof(self) sentence is avoided, so this patch fixes that compilation problem from now on.