### PR TITLE
invert mute icon

### DIFF
--- a/PubNative/Components/Common/Video/PNVideoPlayerView.xib
+++ b/PubNative/Components/Common/Video/PNVideoPlayerView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PNVideoPlayerView">
@@ -42,10 +42,10 @@
                         <constraint firstAttribute="height" constant="50" id="8Kl-ae-dtk"/>
                         <constraint firstAttribute="width" constant="50" id="FGg-ZT-iWs"/>
                     </constraints>
-                    <state key="normal" image="PnMute.png">
+                    <state key="normal" image="PnUnMute.png">
                         <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                     </state>
-                    <state key="selected" image="PnUnMute.png"/>
+                    <state key="selected" image="PnMute.png"/>
                     <connections>
                         <action selector="muteAd:" destination="-1" eventType="touchUpInside" id="RmS-vc-sRd"/>
                     </connections>

--- a/PubNativeDemo/PubNativeDemo/Info.plist
+++ b/PubNativeDemo/PubNativeDemo/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>57</string>
+	<string>58</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/PubNativeDemo/PubnativeDemo WatchKit App/Info.plist
+++ b/PubNativeDemo/PubnativeDemo WatchKit App/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>57</string>
+	<string>58</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/PubNativeDemo/PubnativeDemo WatchKit Extension/Info.plist
+++ b/PubNativeDemo/PubnativeDemo WatchKit Extension/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>57</string>
+	<string>58</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>


### PR DESCRIPTION
This patch inverts the mute button in the icon to do it show the current state of the volume and not the action to be taken